### PR TITLE
Fix URL to feeds

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -9,5 +9,5 @@
 <!--[if lt IE 7]><link rel="stylesheet" type="text/css" href="/css/ie6hacks.css" /><![endif]-->
 
 <link rel="shortcut icon" href="favicon.ico" type="image/x-icon" />
-<link rel="alternate" type="application/rss+xml" title="Roundcube News Feed" href="https://sourceforge.net/export/rss2_projnews.php?group_id=139281" />
+<link rel="alternate" type="application/rss+xml" title="Roundcube News Feed" href="/feeds/atom.xml" />
 <link href="https://plus.google.com/117198963145106512069" rel="publisher" />


### PR DESCRIPTION
The feeds URL still linked to the SF.net news
