### PR TITLE
Logo missing on sub pages

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -14,7 +14,7 @@
 	<div class="rightshadow"></div>
 
 	<div id="header">
-		<a href="./"><img src="images/logo.png" class="pngimage" width="212" height="56" alt="Roundcube - open source webmail software" /></a>
+		<a href="/"><img src="/images/logo.png" class="pngimage" width="212" height="56" alt="Roundcube - open source webmail software" /></a>
 		{% include nav.html %}
 	</div>
 


### PR DESCRIPTION
The logo don't get shown on sub pages like /about. It also not linked to the root page.
