### PR TITLE
Change to better SF download links

### DIFF
--- a/download/index.html
+++ b/download/index.html
@@ -22,25 +22,25 @@ lastmod: 2014-12-18T16:52:00Z
 			<tbody>
 			<tr class="even">
 				<td class="dlversion"><strong>Complete</Strong>: 1.0.4</td>
-				<td class="dlbutton"><a href="http://sourceforge.net/projects/roundcubemail/files/roundcubemail/1.0.4/roundcubemail-1.0.4.tar.gz/download" title="Download now!"><img src="images/table_button_download.png" width="67" height="19" alt="Download" class="pngimage" /></a>
+				<td class="dlbutton"><a href="http://downloads.sourceforge.net/project/roundcubemail/roundcubemail/1.0.4/roundcubemail-1.0.4.tar.gz" title="Download now!"><img src="images/table_button_download.png" width="67" height="19" alt="Download" class="pngimage" /></a>
 				<td class="dlsize">3.9 MB</td>
 				<td class="dlchecksum">c59476d62e24dec484be69bbb2412d84</td>
 			</tr>
 			<tr class="odd">
 				<td class="dlversion"><strong>GPL (dependent *)</strong>: 1.0.4</td>
-				<td class="dlbutton"><a href="http://sourceforge.net/projects/roundcubemail/files/roundcubemail-dependent/1.0.4/roundcubemail-1.0.4-dep.tar.gz/download" title="Download now!"><img src="images/table_button_download.png" width="67" height="19" alt="Download" class="pngimage" /></a>
+				<td class="dlbutton"><a href="http://downloads.sourceforge.net/project/roundcubemail/roundcubemail-dependent/1.0.4/roundcubemail-1.0.4-dep.tar.gz" title="Download now!"><img src="images/table_button_download.png" width="67" height="19" alt="Download" class="pngimage" /></a>
 				<td class="dlsize">3.6 MB</td>
 				<td class="dlchecksum">0001b3bf689103f89d82ded91a7c4775</td>
 			</tr>
 			<tr class="even">
 				<td class="dlversion"><strong>Framework</strong>: 1.0.4</td>
-				<td class="dlbutton"><a href="http://sourceforge.net/projects/roundcubemail/files/roundcubemail/1.0.4/roundcube-framework-1.0.4.tar.gz/download" title="Download now!"><img src="images/table_button_download.png" width="67" height="19" alt="Download" class="pngimage" /></a>
+				<td class="dlbutton"><a href="http://downloads.sourceforge.net/project/roundcubemail/roundcubemail/1.0.4/roundcube-framework-1.0.4.tar.gz" title="Download now!"><img src="images/table_button_download.png" width="67" height="19" alt="Download" class="pngimage" /></a>
 				<td class="dlsize">978 KB</td>
 				<td class="dlchecksum">231eb4a2c0256f518332b10c8d7976cd</td>
 			</tr>
 			<tr class="odd">
 				<td class="dlversion"><strong>Old Version</strong>: 0.9.5</td>
-				<td class="dlbutton"><a href="http://sourceforge.net/projects/roundcubemail/files/roundcubemail/0.9.5/roundcubemail-0.9.5.tar.gz/download" title="Download now!"><img src="images/table_button_download.png" width="67" height="19" alt="Download" class="pngimage" /></a>
+				<td class="dlbutton"><a href="http://downloads.sourceforge.net/project/roundcubemail/roundcubemail/0.9.5/roundcubemail-0.9.5.tar.gz" title="Download now!"><img src="images/table_button_download.png" width="67" height="19" alt="Download" class="pngimage" /></a>
 				<td class="dlsize">3.5 MB</td>
 				<td class="dlchecksum">757f6ab3306d4abf8da6664ae65138d7</td>
 			</tr>
@@ -59,19 +59,19 @@ lastmod: 2014-12-18T16:52:00Z
 			<tbody>
 			<tr class="even">
 				<td class="dlversion"><strong>Dependent (*)</strong>: 1.1-beta</td>
-				<td class="dlbutton"><a href="http://sourceforge.net/projects/roundcubemail/files/roundcubemail-beta/1.1-beta/roundcubemail-1.1-beta.tar.gz/download" title="Download now!"><img src="images/table_button_download.png" width="67" height="19" alt="Download" class="pngimage" /></a>
+				<td class="dlbutton"><a href="http://downloads.sourceforge.net/project/roundcubemail/roundcubemail-beta/1.1-beta/roundcubemail-1.1-beta.tar.gz" title="Download now!"><img src="images/table_button_download.png" width="67" height="19" alt="Download" class="pngimage" /></a>
 				<td class="dlsize">3.2 MB</td>
 				<td class="dlchecksum">6d3a83abed204cbc80f6a06dbbb083dc</td>
 			</tr>
 			<tr class="odd">
 				<td class="dlversion"><strong>Complete</Strong>: 1.1-beta</td>
-				<td class="dlbutton"><a href="http://sourceforge.net/projects/roundcubemail/files/roundcubemail-beta/1.1-beta/roundcubemail-1.1-beta-complete.tar.gz/download" title="Download now!"><img src="images/table_button_download.png" width="67" height="19" alt="Download" class="pngimage" /></a>
+				<td class="dlbutton"><a href="http://downloads.sourceforge.net/project/roundcubemail/roundcubemail-beta/1.1-beta/roundcubemail-1.1-beta-complete.tar.gz" title="Download now!"><img src="images/table_button_download.png" width="67" height="19" alt="Download" class="pngimage" /></a>
 				<td class="dlsize">4.7 MB</td>
 				<td class="dlchecksum">c65c1cfb2fc439ff1ca8b94eeecfbcf3</td>
 			</tr>
 			<tr class="even">
 				<td class="dlversion"><strong>Framework</strong>: 1.1-beta</td>
-				<td class="dlbutton"><a href="http://sourceforge.net/projects/roundcubemail/files/roundcubemail-beta/1.1-beta/roundcube-framework-1.1-beta.tar.gz/download" title="Download now!"><img src="images/table_button_download.png" width="67" height="19" alt="Download" class="pngimage" /></a>
+				<td class="dlbutton"><a href="http://downloads.sourceforge.net/project/roundcubemail/roundcubemail-beta/1.1-beta/roundcube-framework-1.1-beta.tar.gz" title="Download now!"><img src="images/table_button_download.png" width="67" height="19" alt="Download" class="pngimage" /></a>
 				<td class="dlsize">1.0 MB</td>
 				<td class="dlchecksum">83e1a18d10f200ba86ea7fd5f316e357</td>
 			</tr>


### PR DESCRIPTION
These links are usable by both wget and web browsers. Sourceforge
automatically redirects the user to the right mirror/page.

Tested with:
- Firefox 34.0.5
- GNU Wget 1.16
