### PR TITLE
break up text on download screen, add links to docker image

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -17,6 +17,7 @@
 
     <ul class="navbar-nav flex-row ml-md-auto d-none d-md-flex">
         <li class="nav-item"><a class="nav-link p-2" aria-label="GitHub" href="https://github.com/roundcube/roundcubemail" target="_blank" rel="noopener"><i class="fab fa-github"></i></a></li>
+        <li class="nav-item"><a class="nav-link p-2" aria-label="DockerHub" href="https://hub.docker.com/r/roundcube/roundcubemail/" target="_blank" rel="noopener"><i class="fab fa-docker"></i></a></li>
         <li class="nav-item"><a class="nav-link p-2" aria-label="GitHub" href="https://twitter.com/roundcube" target="_blank" rel="noopener"><i class="fab fa-twitter"></i></a></li>
     </ul>
   </div>

--- a/download/index.html
+++ b/download/index.html
@@ -42,22 +42,48 @@ lastmod: 2019-08-28T12:32:00Z
     packages to be installed along with Roundcube. All requirements are listed in the INSTALL instructions within the package file.</p>
 
 <h2>Other sources and downloads</h2>
-<ul>
-    <li>All recent versions are listed on our <a href="https://github.com/roundcube/roundcubemail/releases" class="external-link" target="_blank">Github releases</a> page - complete with release notes and signatures.</li>
-    <li>Roundcube can also be installed through auto installers like <a href="https://www.softaculous.com/" class="external-link" target="_blank">softaculous.com</a>
-        or <a href="https://www.cpanel.net/" class="external-link" target="_blank">cPanel.</a></li>
-    <li>The <a href="https://bitnami.com/stack/roundcube" class="external-link" target="_blank">BitNami Roundcube Stack</a> provides a one-click installer for various platforms and cloud services.</li>
-    <li>Via the <a href="https://cloudron.io/appstore.html?app=net.roundcube.cloudronapp" class="external-link" target="_blank">Cloudron</a> app store.
-        Each Cloudron is a fully equipped mail server and has sieve integration.</li>
-    <li>Pull a Docker image with Roundcube pre-configured to run standalone or with a MySQL database from
-        <a href="https://hub.docker.com/r/roundcube/roundcubemail/" class="external-link" target="_blank">Docker Hub</a>.</li>
-    <li>Various Unix/Linux distributions provide Roundcube via their package managers. Check your local package repository.</li>
-    <li>For a complete list of releases and release notes please check out the releases page
-        at <a href="https://github.com/roundcube/roundcubemail/releases" class="external-link" target="_blank">GitHub</a> and the archives at
-        <a href="https://sourceforge.net/projects/roundcubemail/files/" class="external-link" target="_blank">sourceforge.net</a>.</li>
-    <li>To get the bleeding edge development version check out the files directly from our
-        <a href="https://github.com/roundcube/roundcubemail/" class="external-link" target="_blank">Github repository</a>.</li>
-</ul>
+<div class="row">
+    <div class="col-12 col-lg-4 my-3">
+        <div class="card h-100">
+            <div class="card-header bg-dark">
+                <span class="text-white"><i class="fab fa-github fa-fw mr-1"></i> GitHub</span>
+            </div>
+            <ul class="list-group list-group-flush">
+                <li class="list-group-item">All recent versions are listed on our <a href="https://github.com/roundcube/roundcubemail/releases" class="external-link" target="_blank">Github releases</a> page - complete with release notes and signatures.</li>
+                <li class="list-group-item">To get the bleeding edge development version check out the files directly from our <a href="https://github.com/roundcube/roundcubemail/" class="external-link" target="_blank">Github repository</a>.</li>
+                <li class="list-group-item">Archives of older releases can be found on <a href="https://sourceforge.net/projects/roundcubemail/files/" class="external-link" target="_blank">sourceforge.net</a>.</li>
+            </ul>
+        </div>
+    </div>
+
+    <div class="col-12 col-lg-4 my-3">
+        <div class="card h-100">
+            <div class="card-header bg-dark">
+                <span class="text-white"><i class="fab fa-docker fa-fw mr-1"></i> Docker</span>
+            </div>
+            <ul class="list-group list-group-flush">
+                <li class="list-group-item">The Roundcube Docker image is available on <a href="https://hub.docker.com/r/roundcube/roundcubemail/" class="external-link" target="_blank">Docker Hub</a>.</li>
+                <li class="list-group-item">More information on Docker and a quick start guide is available in the <a href="https://docs.docker.com/" class="external-link" target="_blank">Docker documentation</a>.</li>
+            </ul>
+        </div>
+    </div>
+
+    <div class="col-12 col-lg-4 my-3">
+        <div class="card h-100">
+            <div class="card-header bg-dark">
+                <span class="text-white"><i class="fas fa-box-open fa-fw mr-1"></i> Other</span>
+            </div>
+            <ul class="list-group list-group-flush">
+                <li class="list-group-item">Roundcube can also be installed through auto installers like <a href="https://www.softaculous.com/" class="external-link" target="_blank">softaculous.com</a>
+                    or <a href="https://www.cpanel.net/" class="external-link" target="_blank">cPanel.</a></li>
+                <li class="list-group-item">The <a href="https://bitnami.com/stack/roundcube" class="external-link" target="_blank">BitNami Roundcube Stack</a> provides a one-click installer for various platforms and cloud services.</li>
+                <li class="list-group-item">Via the <a href="https://cloudron.io/appstore.html?app=net.roundcube.cloudronapp" class="external-link" target="_blank">Cloudron</a> app store.
+                    Each Cloudron is a fully equipped mail server and has sieve integration.</li>
+                <li class="list-group-item">Various Unix/Linux distributions provide Roundcube via their package managers. Check your local package repository.</li>
+            </ul>
+        </div>
+    </div>
+</div>
 
 <h2>PGP signatures for package verification</h2>
 <p>Release tarballs listed above are signed with PGP to allow you to verify the authencity. We sign them with
@@ -85,18 +111,56 @@ lastmod: 2019-08-28T12:32:00Z
 
 <h2>Complete Email Server Packages with Roundcube</h2>
 
-<p>The <a href="https://kolab.org" class="font-weight-bold" target="_blank">Kolab Groupware</a> Solution provides a complete email and groupware server pre-packaged for various linux distributions
-  with Roundcube sitting on top as its web client. It offers easy configurable LDAP address books, calendars, tasks, mobile synchronization and more.
-  An enterprise version with professional support is available from <a href="https://kolabsystems.com" class="external-link" target="_blank">Kolab Systems</a>.</p>
+<div class="row">
+    <div class="col-12 col-md-6 col-lg-4 my-3">
+        <div class="card h-100">
+            <div class="card-header bg-dark">
+                <span class="text-white">Kolab Groupware</span>
+            </div>
+            <div class="card-body">
+                <p>The <a href="https://kolab.org" class="font-weight-bold" target="_blank">Kolab Groupware</a> Solution provides a complete email and groupware server pre-packaged for various linux distributions
+                  with Roundcube sitting on top as its web client. It offers easy configurable LDAP address books, calendars, tasks, mobile synchronization and more.
+                  An enterprise version with professional support is available from <a href="https://kolabsystems.com" class="external-link" target="_blank">Kolab Systems</a>.</p>
+            </div>
+        </div>
+    </div>
 
-<p><a href="https://www.iredmail.org" class="font-weight-bold" target="_blank">iRedMail</a> is another fully open source email server solution
-    that lets you install a full-featured email server in a few minutes. It installs and configures the popular open source email
-    components like Postfix, Dovecot, Amavisd and - of course Roundcube - on major Linux and BSD distrubutions.</p>
+    <div class="col-12 col-md-6 col-lg-4 my-3">
+        <div class="card h-100">
+            <div class="card-header bg-dark">
+                <span class="text-white">iRedMail</span>
+            </div>
+            <div class="card-body">
+                <p><a href="https://www.iredmail.org" class="font-weight-bold" target="_blank">iRedMail</a> is another fully open source email server solution
+                    that lets you install a full-featured email server in a few minutes. It installs and configures the popular open source email
+                    components like Postfix, Dovecot, Amavisd and - of course Roundcube - on major Linux and BSD distrubutions.</p>
+            </div>
+        </div>
+    </div>
 
-<p><a href="https://mailinabox.email" class="font-weight-bold" target="_blank">Mail-in-a-Box</a> turns a fresh cloud computer into a
-    fully equipped, working mail server. The setup provides Roundcube webmail and an IMAP/SMTP server for use with
-    mobile devices and desktop mail software. It also includes contacts and calendar synchronization.</p>
+    <div class="col-12 col-md-6 col-lg-4 my-3">
+        <div class="card h-100">
+            <div class="card-header bg-dark">
+                <span class="text-white">Mail-in-a-Box</span>
+            </div>
+            <div class="card-body">
+                <p><a href="https://mailinabox.email" class="font-weight-bold" target="_blank">Mail-in-a-Box</a> turns a fresh cloud computer into a
+                    fully equipped, working mail server. The setup provides Roundcube webmail and an IMAP/SMTP server for use with
+                    mobile devices and desktop mail software. It also includes contacts and calendar synchronization.</p>
+            </div>
+        </div>
+    </div>
 
-<p><a href="https://mailcow.email" class="font-weight-bold" target="_blank">mailcow</a> is an open source mail server suite for groupware/email purposes that can be installed
-    in a fresh Debian/Ubuntu instance. It is powered by various open source mail server components (Dovecot, Postfix, ...) that can be administered
-    in its modern web UI. It also comes with IMAP, POP3 and SMTP support as an alternative to Roundcube webmail.</p>
+    <div class="col-12 col-md-6 col-lg-4 my-3">
+        <div class="card h-100">
+            <div class="card-header bg-dark">
+                <span class="text-white">mailcow</span>
+            </div>
+            <div class="card-body">
+                <p><a href="https://mailcow.email" class="font-weight-bold" target="_blank">mailcow</a> is an open source mail server suite for groupware/email purposes that can be installed
+                in a fresh Debian/Ubuntu instance. It is powered by various open source mail server components (Dovecot, Postfix, ...) that can be administered
+                in its modern web UI. It also comes with IMAP, POP3 and SMTP support as an alternative to Roundcube webmail.</p>
+            </div>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
slight reworking of the download page to break up the large blocks of text using bootstrap cards.

also add the docker icon to the nav bar and link to docker hub

note: once BS 4.4.0 is released this could use responsive card decks