### PR TITLE
replace openhub with shields.io

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,7 +1,7 @@
 <footer class="text-body-secondary w-100 mt-auto pt-3 small bg-body-tertiary">
     <div class="container">
         <div class="row">
-            <div class="col-sm-6">
+            <div class="col-12 col-sm-6">
                 <ul class="m-0 p-0">
                     <li><a href="/support">Support</a></li>
                     <li><a href="/contact">Contact</a></li>
@@ -21,9 +21,11 @@
                     </li>
                 </ul>
             </div>
-            <div class="col-sm-6 text-end d-none d-sm-block">
+            <div class="col-12 col-sm-6 mt-4 mt-sm-0 text-sm-end">
                 <ul class="m-0 p-0">
-                    <li><script src="https://www.openhub.net/p/240/widgets/project_thin_badge.js"></script></li>
+                    <li><a aria-label="GitHub" href="https://github.com/roundcube/roundcubemail" target="_blank" rel="noopener"><img src="https://img.shields.io/github/stars/roundcube/roundcubemail?color=%23066da5&label=stars&logo=github&logoColor=%23fff&style=flat-square" alt="GitHub Stars"></li>
+                    <li><a aria-label="GitHub Contributors" href="https://github.com/roundcube/roundcubemail/graphs/contributors" target="_blank" rel="noopener"><img src="https://img.shields.io/github/contributors/roundcube/roundcubemail?color=%23066da5&label=contributors&logo=github&logoColor=%23fff&style=flat-square" alt="GitHub Contributors"></li>
+                    <li><a aria-label="DockerHub" href="https://hub.docker.com/r/roundcube/roundcubemail/" target="_blank" rel="noopener"><img src="https://img.shields.io/docker/pulls/roundcube/roundcubemail?color=%23066da5&label=pulls&logo=docker&logoColor=%23fff&style=flat-square" alt="Docker Downloads"></li>
                 </ul>
             </div>
         </div>


### PR DESCRIPTION
**Requires https://github.com/roundcube/roundcube.github.com/pull/55 first**

idea: replace the current openhub widget in the footer with badges from shields.io

![Untitled-1](https://github.com/roundcube/roundcube.github.com/assets/88682/2a09a792-4484-4b3b-a708-528e50463ea6)

Note from shields.io
> If your GitHub badge errors, it might be because you hit GitHub's rate limits. You can increase Shields.io's rate limit by [adding the Shields GitHub application](https://img.shields.io/github-auth) using your GitHub account.

Please add the app if you merge this PR.