### PR TITLE
Fix broken link transifex

### DIFF
--- a/contribute/index.html
+++ b/contribute/index.html
@@ -48,7 +48,7 @@ Thanks for keeping the list on-topic and productive!</p>
             </div>
             <div class="card-body">
                 <p>We have moved our translations to <b>Transifex</b> where you can all contribute and help to keep the translations up-to-date.
-                Go to <a href="https://www.transifex.com/projects/p/roundcube-webmail/" class="rc-icon external-link" target="_blank">transifex.com</a> and register yourself as a Transifex user.
+                Go to <a href="https://explore.transifex.com/roundcube/" class="rc-icon external-link" target="_blank">transifex.com</a> and register yourself as a Transifex user.
                 In order to start translating, you have to become a member of the translation team for your language.
                 To do so, choose your language from the list and then click "Join team" on the upper right part of the overview page.
                 Your request will be proceeded as fast as possible.</p>


### PR DESCRIPTION
Fix broken link to transifex translation project of Roundcube. The current link does NOT go to the Roundcube project.