### PR TITLE
update version number

### DIFF
--- a/_data/releases.json
+++ b/_data/releases.json
@@ -42,7 +42,7 @@
     },
     "beta": {
         "name": "Release candidate",
-        "version": "1.7-rc3",
+        "version": "1.7-rc4",
         "sources": [
             {
                 "package": "Dependent",


### PR DESCRIPTION
the download screen still says rc3.

i'll create a separate pr to rework the `releases.json` file a bit and avoid having to put the version number multiple times.