### PR TITLE
Fix serve-dev and explicit dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,6 @@
 source 'https://rubygems.org'
-gem 'github-pages'
-
-# Explicitly require v4.0.4 to fix "Liquid Exception: undefined method 'tainted?' for an instance of String". See <https://github.com/jekyll/jekyll/issues/9233>.
-gem 'liquid', '>=4.0.4'
+# Explicitly require >=232 to make sure liquid >=4.0.4 is used, which has a fix for "Liquid Exception: undefined method 'tainted?' for an instance of String". See <https://github.com/jekyll/jekyll/issues/9233>.
+gem 'github-pages', '>=232'
 
 # Require some gems that are not part of the core anymore in recent Ruby versions.
 gem 'csv'

--- a/Makefile
+++ b/Makefile
@@ -9,4 +9,4 @@ css:
 	npx less --clean-css="--s1 --advanced"  styles/styles.less > styles/styles.min.css
 
 serve-dev:
-	docker run -it -p 4000:4000 -v $(PWD):/site -w /site library/ruby bash -c 'bundle install && bundle exec jekyll serve -H 0.0.0.0'
+	docker run -it -p 4000:4000 -v $(PWD):/site -w /site library/ruby:3 bash -c 'bundle install && bundle exec jekyll serve -H 0.0.0.0'


### PR DESCRIPTION
github-pages isn't compatible with Ruby 4, since its dependency
jekyll-commonmark depends on a very old version of commonmarker, which isn't
compatible with Ruby 4.

The latest release of jekyll-commonmark was in January 2022, so maybe this is
a sign that we'll have to look for alternatives.

Signed-off-by: Pablo Zmdl <pablo@nextcloud.com>