### PR TITLE
rename and rework releases.json for easier management

### DIFF
--- a/VERSION.txt
+++ b/VERSION.txt
@@ -1,3 +1,3 @@
 ---
 ---
-{{ site.data.releases.stable.version }}
+{{ site.data.downloads.stable.packages[0].version }}

--- a/_bin/generate-downloads-json-data.php
+++ b/_bin/generate-downloads-json-data.php
@@ -31,6 +31,7 @@ function generate_data($version, $package_name, $basedir, $filename)
     return [
         'package' => $package_name,
         'url' => "https://github.com/roundcube/roundcubemail/releases/download/{$version}/{$filename}",
+        'version' => $version,
         'size' => $size,
         'checksum' => $sum,
     ];

--- a/_data/downloads.json
+++ b/_data/downloads.json
@@ -1,64 +1,81 @@
 {
     "stable": {
-        "name": "Stable version",
-        "version": "1.6.15",
-        "sources": [
+        "title": "Stable version",
+        "titleVersion": true,
+        "packages": [
             {
                 "package": "Dependent",
                 "url": "https://github.com/roundcube/roundcubemail/releases/download/1.6.15/roundcubemail-1.6.15.tar.gz",
+                "version": "1.6.15",
                 "size": "3.7 MB",
                 "checksum": "9e415d4f6c29a60c9495a614ffeb9e2786601f74093b4a0a2b9cba0c32535efa"
             },
             {
                 "package": "Complete",
                 "url": "https://github.com/roundcube/roundcubemail/releases/download/1.6.15/roundcubemail-1.6.15-complete.tar.gz",
+                "version": "1.6.15",
                 "size": "5.6 MB",
                 "checksum": "48c9f212c77460132491f670abaf440b765c8276268349a690913764d26afbef"
             },
             {
                 "package": "Framework",
                 "url": "https://github.com/roundcube/roundcubemail/releases/download/1.6.15/roundcube-framework-1.6.15.tar.gz",
+                "version": "1.6.15",
                 "size": "1.1 MB",
                 "checksum": "a90770a8b0a17dfe4fe78d98abce1c4219c4c05bb2b6f08178d9cdff587434bf"
             }
         ]
     },
     "old-stable": {
-        "name": "Old stable",
-        "version": "1.5.3",
-        "sources": [
+        "title": "Old stable",
+        "titleVersion": true,
+        "packages": [
         ]
     },
     "lts": {
-        "name": "LTS versions",
-        "sources": [
+        "title": "LTS versions",
+        "titleVersion": false,
+        "description": "Long Term Support with low maintenance mode. This means only security updates and rare fixes of serious issues will go into these release branches.",
+        "packages": [
             {
-                "package": "1.5.15 - Complete",
+                "package": "Complete",
                 "url": "https://github.com/roundcube/roundcubemail/releases/download/1.5.15/roundcubemail-1.5.15-complete.tar.gz",
+                "version": "1.5.15",
                 "size": "7.2 MB",
                 "checksum": "ed96857435066e8cedc0dfa7c3965fd89263e69ba4951385f09939a38b938c28"
             }
         ]
     },
     "beta": {
-        "name": "Release candidate",
-        "version": "1.7-rc6",
-        "sources": [
+        "title": "Beta version",
+        "titleVersion": true,
+        "description": "We recommend to test pre-release versions on a separate environment, and don't forget to backup your data before installing.",
+        "packages": [
+        ]
+    },
+    "rc": {
+        "title": "Release candidate",
+        "titleVersion": true,
+        "description": "We recommend to test pre-release versions on a separate environment, and don't forget to backup your data before installing.",
+        "packages": [
             {
                 "package": "Dependent",
                 "url": "https://github.com/roundcube/roundcubemail/releases/download/1.7-rc6/roundcubemail-1.7-rc6.tar.gz",
+                "version": "1.7-rc6",
                 "size": "4.0 MB",
                 "checksum": "97a2c6fa98d997a5a0689680d73586d3b120e44755704be5c612bcc7f46df75f"
             },
             {
                 "package": "Complete",
                 "url": "https://github.com/roundcube/roundcubemail/releases/download/1.7-rc6/roundcubemail-1.7-rc6-complete.tar.gz",
+                "version": "1.7-rc6",
                 "size": "6.1 MB",
                 "checksum": "c68a7cf44c2f23adc76b3283aadb09c3d2921bd24efec1e9e14e57927c924265"
             },
             {
                 "package": "Framework",
                 "url": "https://github.com/roundcube/roundcubemail/releases/download/1.7-rc6/roundcube-framework-1.7-rc6.tar.gz",
+                "version": "1.7-rc6",
                 "size": "1.1 MB",
                 "checksum": "4ad67b65f28c4c15a8e16e93f2c6aa4c9ab05191fec796491980a88a1b4d0eff"
             }

--- a/download/index.html
+++ b/download/index.html
@@ -6,21 +6,18 @@ lastmod: 2019-08-28T12:32:00Z
 ---
 <h1>Download your version of Roundcube</h1>
 
-{% for version in site.data.releases %}
-    {% assign id = version | first %}
-    {% assign params = version | last %}
+{% for downlad in site.data.downloads %}
+    {% assign id = downlad | first %}
+    {% assign params = downlad | last %}
 
-    {% if params.sources.size == 0 %}
+    {% if params.packages.size == 0 %}
         {% continue %}
     {% endif %}
 
-    <h2 id="{{ id }}">{{ params.name }}{% if params.version %} - {{ params.version }}{% endif %} <a class="anchor" href="#{{ id }}" aria-label="Link to this section: {{ id }}"></a></h2>
+    <h2 id="{{ id }}">{{ params.title }}{% if params.titleVersion %} - {{ params.packages[0].version }}{% endif %} <a class="anchor" href="#{{ id }}" aria-label="Link to this section: {{ params.title }}"></a></h2>
 
-    {% if id == "lts" %}
-        <p class="text-body-secondary mb-1">Long Term Support with low maintenance mode. This means only security updates and rare fixes of serious issues
-            will go into these release branches.</p>
-    {% elsif id == "beta" %}
-        <p class="text-body-secondary mb-1">We recommend to test beta versions on a separate environment, and don't forget to backup your data before installing.</p>
+    {% if params.description %}
+        <p class="text-body-secondary mb-1">{{ params.description }}</p>
     {% endif %}
 
     <table class="table table-striped download-table">
@@ -33,14 +30,14 @@ lastmod: 2019-08-28T12:32:00Z
         </tr>
     </thead>
     <tbody>
-        {% for source in params.sources %}
+        {% for package in params.packages %}
             <tr>
-                <th class="package fw-normal" scope="row">{{ source.package }}{% if source.package == "Dependent" %}<sup><a href="#fn1" class="text-body-secondary">1</a></sup>{% endif %}</th>
-                <td class="link text-center text-lg-start"><a href="{{ source.url }}" title="Download now!" class="btn rc-icon btn-rc-download btn-sm"><span>Download</span></a></td>
-                <td class="size text-nowrap">{{ source.size }}</td>
+                <th class="package fw-normal" scope="row">{% unless params.titleVersion %}{{ package.version }} - {% endunless %}{{ package.package }}{% if package.package == "Dependent" %}<sup><a href="#fn1" class="text-body-secondary">1</a></sup>{% endif %}</th>
+                <td class="link text-center text-lg-start"><a href="{{ package.url }}" title="Download now!" class="btn rc-icon btn-rc-download btn-sm"><span>Download</span></a></td>
+                <td class="size text-nowrap">{{ package.size }}</td>
                 <td class="checksum font-monospace text-nowrap text-center text-lg-start pe-3">
                     <span class="d-none d-lg-inline copy-popover-target">
-                        <span class="copy-target d-block d-lg-inline text-nowrap overflow-auto py-3 py-lg-0">{{ source.checksum }}</span><span class="py-3 py-lg-0"><a class="copy-link" href="#" aria-label="Copy text"></a></span>
+                        <span class="copy-target d-block d-lg-inline text-nowrap overflow-auto py-3 py-lg-0">{{ package.checksum }}</span><span class="py-3 py-lg-0"><a class="copy-link" href="#" aria-label="Copy text"></a></span>
                     </span>
                     <a class="d-inline d-lg-none copy-popover-link checksum" href="#" aria-label="SHA-256 checksum" onclick="return false;" data-bs-title="SHA-256 checksum" data-bs-placement="left"></a>
                 </td>

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@ date: 2020-04-29T21:10:00Z
             </div>
             <div class="download text-center d-flex flex-column justify-content-center justify-content-lg-start align-items-center pt-xl-4">
                 <a href="/download" class="btn rc-icon btn-rc-download btn-lg" title="Download now!">Download</a>
-                <span class="version text-body-secondary">Version {{ site.data.releases.stable.version }}</span>
+                <span class="version text-body-secondary">Version {{ site.data.downloads.stable.packages[0].version }}</span>
             </div>
         </div>
     </div>


### PR DESCRIPTION
I renamed the file just for consistency with other data files. the new structure should be easier to manage as the version number is not separate any more.